### PR TITLE
Makefile changes mainly (ignore test and undo test commits)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,18 @@ DOCKER := $(shell command -v docker)
 	echo "DISPLAY=$(DISPLAY)" >> .env
 	echo "CASA_VERSION=$(CASA_VERSION)" >> .env
 
-compose: .env xhost ensureborders down  # Is this "down" really necessary? .env runs clean, which runs stop, running "docker compose down || true"
-
+# first function without dot is assigned to command "make"=="make compose".
+# This function builds the container and applies changes to other files.
+compose: .env xhost ensureborders
 	docker compose build
 	docker compose up -d casa
 	docker compose exec -it casa bash
 
+# function to run on system start-up: starts the casa container.
+start: ensureborders
+	docker compose up -d casa
+
+# function to re-open the shell if the container is running
 connect:
 	docker compose exec -it casa bash
 
@@ -48,6 +54,7 @@ xhost:
 down:
 	docker compose down
 
+# function to stop the container
 stop:
 	docker compose kill || true
 	docker compose down || true
@@ -58,5 +65,6 @@ clean: stop
 cleanexternaldata:
 	rm -rf dotcasa/data/*
 
+# Reinitialize mutter to ensure borders on hosts with GNOME ~46. Ignore related warnings if any.
 ensureborders:
-	pkill -HUP mutter-x11  # Reinitialize mutter to ensure borders on hosts with GNOME ~46. Ignore related warnings if any.
+	pkill -HUP mutter-x11

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ compose: .env xhost ensureborders
 # function to start container on host start-up, and/or connect to container shell
 start: ensureborders
 	docker compose up -d casa
-	docker compose excec -it casa bash
-	
+	docker compose exec -it casa bash
+
 # function to stop the container
 stop:
 	docker compose kill || true

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,15 @@ compose: .env xhost ensureborders
 	docker compose up -d casa
 	docker compose exec -it casa bash
 
-# function to run on system start-up: starts the casa container.
+# function to start container on host start-up, and/or connect to container shell
 start: ensureborders
 	docker compose up -d casa
-
-# function to re-open the shell if the container is running
-connect:
-	docker compose exec -it casa bash
+	docker compose excec -it casa bash
+	
+# function to stop the container
+stop:
+	docker compose kill || true
+	docker compose down || true
 
 host-deps:
 	make install-docker
@@ -54,17 +56,11 @@ xhost:
 down:
 	docker compose down
 
-# function to stop the container
-stop:
-	docker compose kill || true
-	docker compose down || true
-
 clean: stop
 	rm .env || true
 
 cleanexternaldata:
 	rm -rf dotcasa/data/*
 
-# Reinitialize mutter to ensure borders on hosts with GNOME ~46. Ignore related warnings if any.
 ensureborders:
 	pkill -HUP mutter-x11

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ DOCKER := $(shell command -v docker)
 
 # first function without dot is assigned to command "make"=="make compose".
 # This function builds the container and applies changes to other files.
-compose: .env xhost ensureborders
+# It also starts the container and opens a shell using function start.
+compose: .env xhost
 	docker compose build
-	docker compose up -d casa
-	docker compose exec -it casa bash
+	make start
 
 # function to start container on host start-up, and/or connect to container shell
 start: ensureborders
@@ -62,5 +62,8 @@ clean: stop
 cleanexternaldata:
 	rm -rf dotcasa/data/*
 
+# For some host configurations, the windows of the CASA GUI have no borders.
+# Main cause is that mutter did not initialize properly on system start-up.
+# This function re-starts mutter.
 ensureborders:
-	pkill -HUP mutter-x11
+	pkill -HUP mutter-x11 || true


### PR DESCRIPTION
- Added comments for main `make` commands
- Removed unnecesary `docker compose down` from build:
    - `docker compose down || true` is already ran at start of  `make compose` with .env->clean->stop.
    - Tested without the last `down` in `compose` and the container is built just fine.
- Removed `make connect` (old `make bash`)
- Added `make start`:
```yaml
start: ensureborders
	docker compose up -d casa
	docker compose exec -it casa bash
```
  